### PR TITLE
fixing the response examples issue when the parsed example is not sim…

### DIFF
--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -329,6 +329,11 @@ function produceResponseExample(method) {
                     response: body.toJSON().example,
                     code: response.code().value()
                 };
+
+                if(typeof apiExample.response === "object"){
+                    apiExample.response = JSON.stringify(body.toJSON().example, null, '  ');
+                }
+
                 if (apiExample.response !== undefined) {
                     try {
                         apiExample.response = apiExample.response && hljs.highlight('json', apiExample.response).value;


### PR DESCRIPTION
When the parsed response example is not simple string, the document can not show the response example. 
I think it is similar to the bug 'Parsing RAML 1.0 response examples #20'.
