### PR TITLE
add http verbs options and head label support

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -172,6 +172,8 @@ html(lang="en")
                                                         when 'put': span(class='label label-info')= endpoint.method
                                                         when 'delete': span(class='label label-danger')= endpoint.method
                                                         when 'patch': span(class='label label-info')= endpoint.method
+                                                        when 'options': span(class='label label-info')= endpoint.method
+                                                        when 'head': span(class='label label-primary')= endpoint.method
                                                     a(href='#' + '#{helpers.uriWithMethodIdentifier(endpoint.uri, endpoint.method)}')= endpoint.uri
                     .col-md-10.col-md-offset-2
                         each documentation in api.apiDocumentations
@@ -201,6 +203,8 @@ html(lang="en")
                                                     when 'put': span(class='label label-info')= endpoint.method
                                                     when 'delete': span(class='label label-danger')= endpoint.method
                                                     when 'patch': span(class='label label-info')= endpoint.method
+                                                    when 'options': span(class='label label-info')= endpoint.method
+                                                    when 'head': span(class='label label-primary')= endpoint.method
                                                 = endpoint.uri
 
                                             div(class='documentation__endpoints__description') !{endpoint.description}


### PR DESCRIPTION
Adding label support for the HEAD and OPTIONS HTTP verbs. The RAML spec supports them via their [https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/#methods](RAML 1.0 Documentation).

This simply adds labels for those methods in the generated HTML so be consistent with the rest of the HTTP verbs